### PR TITLE
majid/data sources

### DIFF
--- a/internal/provider/client/gvcs.go
+++ b/internal/provider/client/gvcs.go
@@ -38,6 +38,12 @@ type GvcSpecUpdate struct {
 	Tracing         *Tracing         `json:"tracing,omitempty"`
 }
 
+// StaticPlacement - Static Placement
+type StaticPlacement struct {
+	LocationLinks *[]string `json:"locationLinks,omitempty"`
+	LocationQuery *Query    `json:"locationQuery,omitempty"`
+}
+
 func (g GvcSpec) MarshalJSON() ([]byte, error) {
 
 	type localGvcSpec GvcSpec
@@ -50,12 +56,6 @@ func (g GvcSpec) MarshalJSON() ([]byte, error) {
 		})
 	}
 	return json.Marshal(localGvcSpec(g))
-}
-
-// StaticPlacement - Static Placement
-type StaticPlacement struct {
-	LocationLinks *[]string `json:"locationLinks,omitempty"`
-	LocationQuery *Query    `json:"locationQuery,omitempty"`
 }
 
 // GetGvcs - Get All Gvcs

--- a/internal/provider/data_source_gvc.go
+++ b/internal/provider/data_source_gvc.go
@@ -13,56 +13,7 @@ func dataSourceGvc() *schema.Resource {
 
 	return &schema.Resource{
 		ReadContext: dataSourceGvcRead,
-		Schema: map[string]*schema.Schema{
-			"cpln_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: NameValidator,
-			},
-			"description": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"domain": {
-				Type:       schema.TypeString,
-				Computed:   true,
-				Deprecated: "Selecting a domain on a GVC will be deprecated in the future. Use cpln_domain instead.",
-			},
-			"alias": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"pull_secrets": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"locations": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"tags": {
-				Type:     schema.TypeMap,
-				Computed: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"self_link": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"lightstep_tracing": client.LightstepSchema(),
-		},
+		Schema:      GvcSchema(),
 	}
 }
 

--- a/internal/provider/resource_gvc.go
+++ b/internal/provider/resource_gvc.go
@@ -18,68 +18,8 @@ func resourceGvc() *schema.Resource {
 		ReadContext:   resourceGvcRead,
 		UpdateContext: resourceGvcUpdate,
 		DeleteContext: resourceGvcDelete,
-		Schema: map[string]*schema.Schema{
-			"cpln_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: NameValidator,
-			},
-			"description": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateFunc:     DescriptionValidator,
-				DiffSuppressFunc: DiffSuppressDescription,
-			},
-			"domain": {
-				Type:       schema.TypeString,
-				Optional:   true,
-				Deprecated: "Selecting a domain on a GVC will be deprecated in the future. Use cpln_domain instead.",
-			},
-			"alias": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"pull_secrets": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"locations": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"tags": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-				ValidateFunc: TagValidator,
-			},
-			"env": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"self_link": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"lightstep_tracing": client.LightstepSchema(),
-		},
-		Importer: &schema.ResourceImporter{},
+		Schema:        GvcSchema(),
+		Importer:      &schema.ResourceImporter{},
 	}
 }
 
@@ -407,4 +347,69 @@ func resourceGvcDelete(_ context.Context, d *schema.ResourceData, m interface{})
 	d.SetId("")
 
 	return nil
+}
+
+func GvcSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+
+		"cpln_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"name": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: NameValidator,
+		},
+		"description": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			ValidateFunc:     DescriptionValidator,
+			DiffSuppressFunc: DiffSuppressDescription,
+		},
+		"domain": {
+			Type:       schema.TypeString,
+			Optional:   true,
+			Deprecated: "Selecting a domain on a GVC will be deprecated in the future. Use cpln_domain instead.",
+		},
+		"alias": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"pull_secrets": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"locations": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"tags": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+			ValidateFunc: TagValidator,
+		},
+		"env": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"self_link": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"lightstep_tracing": client.LightstepSchema(),
+	}
 }


### PR DESCRIPTION
An issue in terraform data source, the user receives this error: Invalid address to set: []string{"env"}
What I did is share the same gvc schema to resource gvc and data source gvc.