### PR TITLE
Fix invalid Go package name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module terraform-provider-cpln
+module github.com/controlplane-com/terraform-provider-cpln
 
 go 1.20
 

--- a/internal/provider/data_source_gvc.go
+++ b/internal/provider/data_source_gvc.go
@@ -3,7 +3,7 @@ package cpln
 import (
 	"context"
 
-	client "terraform-provider-cpln/internal/provider/client"
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/data_source_gvcs.go
+++ b/internal/provider/data_source_gvcs.go
@@ -3,8 +3,9 @@ package cpln
 import (
 	"context"
 	"strconv"
-	client "terraform-provider-cpln/internal/provider/client"
 	"time"
+
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/data_source_location.go
+++ b/internal/provider/data_source_location.go
@@ -3,7 +3,7 @@ package cpln
 import (
 	"context"
 
-	client "terraform-provider-cpln/internal/provider/client"
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/data_source_locations.go
+++ b/internal/provider/data_source_locations.go
@@ -3,8 +3,9 @@ package cpln
 import (
 	"context"
 	"strconv"
-	client "terraform-provider-cpln/internal/provider/client"
 	"time"
+
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/data_source_org.go
+++ b/internal/provider/data_source_org.go
@@ -2,7 +2,8 @@ package cpln
 
 import (
 	"context"
-	client "terraform-provider-cpln/internal/provider/client"
+
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/helper.go
+++ b/internal/provider/helper.go
@@ -6,7 +6,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	client "terraform-provider-cpln/internal/provider/client"
+
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -3,7 +3,7 @@ package cpln
 import (
 	"context"
 
-	client "terraform-provider-cpln/internal/provider/client"
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/resource_agent.go
+++ b/internal/provider/resource_agent.go
@@ -3,7 +3,7 @@ package cpln
 import (
 	"context"
 
-	client "terraform-provider-cpln/internal/provider/client"
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/resource_agent_test.go
+++ b/internal/provider/resource_agent_test.go
@@ -2,8 +2,9 @@ package cpln
 
 import (
 	"fmt"
-	client "terraform-provider-cpln/internal/provider/client"
 	"testing"
+
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/internal/provider/resource_auditcontext.go
+++ b/internal/provider/resource_auditcontext.go
@@ -2,7 +2,8 @@ package cpln
 
 import (
 	"context"
-	client "terraform-provider-cpln/internal/provider/client"
+
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/resource_auditcontext_test.go
+++ b/internal/provider/resource_auditcontext_test.go
@@ -2,8 +2,9 @@ package cpln
 
 import (
 	"fmt"
-	client "terraform-provider-cpln/internal/provider/client"
 	"testing"
+
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/internal/provider/resource_cloudaccount.go
+++ b/internal/provider/resource_cloudaccount.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	client "terraform-provider-cpln/internal/provider/client"
+
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/resource_cloudaccount_test.go
+++ b/internal/provider/resource_cloudaccount_test.go
@@ -3,8 +3,9 @@ package cpln
 import (
 	"fmt"
 	"os"
-	client "terraform-provider-cpln/internal/provider/client"
 	"testing"
+
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/internal/provider/resource_domain.go
+++ b/internal/provider/resource_domain.go
@@ -3,7 +3,7 @@ package cpln
 import (
 	"context"
 
-	client "terraform-provider-cpln/internal/provider/client"
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/resource_domain_route.go
+++ b/internal/provider/resource_domain_route.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	client "terraform-provider-cpln/internal/provider/client"
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/resource_domain_test.go
+++ b/internal/provider/resource_domain_test.go
@@ -2,8 +2,9 @@ package cpln
 
 import (
 	"fmt"
-	client "terraform-provider-cpln/internal/provider/client"
 	"testing"
+
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/go-test/deep"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"

--- a/internal/provider/resource_group.go
+++ b/internal/provider/resource_group.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	client "terraform-provider-cpln/internal/provider/client"
+
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/resource_group_test.go
+++ b/internal/provider/resource_group_test.go
@@ -2,8 +2,9 @@ package cpln
 
 import (
 	"fmt"
-	client "terraform-provider-cpln/internal/provider/client"
 	"testing"
+
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/go-test/deep"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"

--- a/internal/provider/resource_gvc.go
+++ b/internal/provider/resource_gvc.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"strings"
 
-	client "terraform-provider-cpln/internal/provider/client"
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/resource_gvc_test.go
+++ b/internal/provider/resource_gvc_test.go
@@ -3,8 +3,9 @@ package cpln
 import (
 	"encoding/json"
 	"fmt"
-	client "terraform-provider-cpln/internal/provider/client"
 	"testing"
+
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/go-test/deep"
 

--- a/internal/provider/resource_identity.go
+++ b/internal/provider/resource_identity.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"strings"
 
-	client "terraform-provider-cpln/internal/provider/client"
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/resource_identity_test.go
+++ b/internal/provider/resource_identity_test.go
@@ -3,8 +3,9 @@ package cpln
 import (
 	"fmt"
 	"os"
-	client "terraform-provider-cpln/internal/provider/client"
 	"testing"
+
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/go-test/deep"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"

--- a/internal/provider/resource_org.go
+++ b/internal/provider/resource_org.go
@@ -3,7 +3,8 @@ package cpln
 import (
 	"context"
 	"fmt"
-	client "terraform-provider-cpln/internal/provider/client"
+
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/resource_org_logging.go
+++ b/internal/provider/resource_org_logging.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"sync"
 
-	client "terraform-provider-cpln/internal/provider/client"
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/resource_org_logging_test.go
+++ b/internal/provider/resource_org_logging_test.go
@@ -2,8 +2,9 @@ package cpln
 
 import (
 	"fmt"
-	client "terraform-provider-cpln/internal/provider/client"
 	"testing"
+
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/go-test/deep"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/internal/provider/resource_org_test.go
+++ b/internal/provider/resource_org_test.go
@@ -3,7 +3,7 @@ package cpln
 import (
 	"testing"
 
-	client "terraform-provider-cpln/internal/provider/client"
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/go-test/deep"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/internal/provider/resource_org_tracing.go
+++ b/internal/provider/resource_org_tracing.go
@@ -3,7 +3,7 @@ package cpln
 import (
 	"context"
 
-	client "terraform-provider-cpln/internal/provider/client"
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/resource_org_tracing_test.go
+++ b/internal/provider/resource_org_tracing_test.go
@@ -2,8 +2,9 @@ package cpln
 
 import (
 	"fmt"
-	client "terraform-provider-cpln/internal/provider/client"
 	"testing"
+
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/go-test/deep"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"

--- a/internal/provider/resource_policy.go
+++ b/internal/provider/resource_policy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	client "terraform-provider-cpln/internal/provider/client"
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/resource_policy_test.go
+++ b/internal/provider/resource_policy_test.go
@@ -2,8 +2,9 @@ package cpln
 
 import (
 	"fmt"
-	client "terraform-provider-cpln/internal/provider/client"
 	"testing"
+
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"sort"
 

--- a/internal/provider/resource_secret.go
+++ b/internal/provider/resource_secret.go
@@ -5,7 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	client "terraform-provider-cpln/internal/provider/client"
+
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/resource_secret_test.go
+++ b/internal/provider/resource_secret_test.go
@@ -2,8 +2,9 @@ package cpln
 
 import (
 	"fmt"
-	client "terraform-provider-cpln/internal/provider/client"
 	"testing"
+
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/go-test/deep"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"

--- a/internal/provider/resource_serviceaccount.go
+++ b/internal/provider/resource_serviceaccount.go
@@ -2,7 +2,8 @@ package cpln
 
 import (
 	"context"
-	client "terraform-provider-cpln/internal/provider/client"
+
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/resource_serviceaccount_test.go
+++ b/internal/provider/resource_serviceaccount_test.go
@@ -2,8 +2,9 @@ package cpln
 
 import (
 	"fmt"
-	client "terraform-provider-cpln/internal/provider/client"
 	"testing"
+
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/internal/provider/resource_serviceaccountkey.go
+++ b/internal/provider/resource_serviceaccountkey.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	client "terraform-provider-cpln/internal/provider/client"
+
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/resource_volumeset.go
+++ b/internal/provider/resource_volumeset.go
@@ -5,7 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	client "terraform-provider-cpln/internal/provider/client"
+
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/resource_volumeset_test.go
+++ b/internal/provider/resource_volumeset_test.go
@@ -3,8 +3,9 @@ package cpln
 import (
 	"fmt"
 	"strings"
-	client "terraform-provider-cpln/internal/provider/client"
 	"testing"
+
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/go-test/deep"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"

--- a/internal/provider/resource_workload.go
+++ b/internal/provider/resource_workload.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	client "terraform-provider-cpln/internal/provider/client"
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/resource_workload_test.go
+++ b/internal/provider/resource_workload_test.go
@@ -3,8 +3,9 @@ package cpln
 import (
 	"encoding/json"
 	"fmt"
-	client "terraform-provider-cpln/internal/provider/client"
 	"testing"
+
+	client "github.com/controlplane-com/terraform-provider-cpln/internal/provider/client"
 
 	"github.com/go-test/deep"
 

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 
-	cpln "terraform-provider-cpln/internal/provider"
+	cpln "github.com/controlplane-com/terraform-provider-cpln/internal/provider"
 )
 
 // Run "go generate" to format example terraform files and generate the docs for the registry/website


### PR DESCRIPTION
Today it's not possible to `go get` the package. I need it to work to be used in pulumi provider.
![image](https://github.com/controlplane-com/terraform-provider-cpln/assets/10233442/008c1e7d-deba-4052-a856-587a0b0ad631)
