### PR TITLE
Sync cpln_agent with API schema

### DIFF
--- a/docs/resources/agent.md
+++ b/docs/resources/agent.md
@@ -28,6 +28,7 @@ The following attributes are exported:
 - **cpln_id** (String) The ID, in GUID format, of the Agent.
 - **self_link** (String) Full link to this resource. Can be referenced by other resources.
 - **user_data** (String, Sensitive) The JSON output needed when [creating an agent](https://docs.controlplane.com/guides/agent).
+- **protocol_version** (String) The wormhole protocol version reported by the agent. Valid values: `v1`, `v2`.
 
 **Note:** The `user_data` output value is only generated when the resource is created. Because of its sensitive nature, the `user_data` value will not be displayed.
 

--- a/internal/provider/client/agent.go
+++ b/internal/provider/client/agent.go
@@ -18,6 +18,7 @@ type AgentBootstrapConfig struct {
 	AgentId           *string `json:"agentId,omitempty"`
 	AgentLink         *string `json:"agentLink,omitempty"`
 	HubEndpoint       *string `json:"hubEndpoint,omitempty"`
+	ProtocolVersion   *string `json:"protocolVersion,omitempty"` // Enum: "v1", "v2"
 }
 
 // GetAgent - Get Agent by name

--- a/internal/provider/client/agent.go
+++ b/internal/provider/client/agent.go
@@ -11,6 +11,7 @@ type Agent struct {
 
 type AgentStatus struct {
 	BootstrapConfig *AgentBootstrapConfig `json:"bootstrapConfig,omitempty"`
+	ProtocolVersion *string               `json:"protocolVersion,omitempty"` // Enum: "v1", "v2"
 }
 
 type AgentBootstrapConfig struct {

--- a/internal/provider/resource_agent.go
+++ b/internal/provider/resource_agent.go
@@ -25,7 +25,8 @@ var (
 // AgentResourceModel holds the Terraform state for the resource.
 type AgentResourceModel struct {
 	EntityBaseModel
-	UserData types.String `tfsdk:"user_data"`
+	UserData        types.String `tfsdk:"user_data"`
+	ProtocolVersion types.String `tfsdk:"protocol_version"`
 }
 
 /*** Resource Configuration ***/
@@ -65,6 +66,13 @@ func (ar *AgentResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				Description: "The JSON output needed when creating an agent.",
 				Computed:    true,
 				Sensitive:   true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"protocol_version": schema.StringAttribute{
+				Description: "The wormhole protocol version reported by the agent. Valid values: `v1`, `v2`.",
+				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -131,6 +139,13 @@ func (aro *AgentResourceOperator) MapResponseToState(agent *client.Agent, isCrea
 		state.UserData = types.StringValue(string(userData))
 	} else {
 		state.UserData = aro.Plan.UserData // :D
+	}
+
+	// Populate protocol_version from the agent status
+	if agent.Status != nil {
+		state.ProtocolVersion = types.StringPointerValue(agent.Status.ProtocolVersion)
+	} else {
+		state.ProtocolVersion = types.StringNull()
 	}
 
 	// Populate common fields from base resource data


### PR DESCRIPTION
## Summary

Sync the `cpln_agent` resource with the API schema (`controlplane/nodelibs/schema/src/agent.ts`). Adds the two `protocolVersion` fields that exist server-side but were missing from the provider:

- `status.bootstrapConfig.protocolVersion` — flows into the existing `user_data` JSON output automatically (no schema change needed).
- `status.protocolVersion` — surfaced as a new Computed `protocol_version` attribute on `cpln_agent`. Valid values: `v1`, `v2`.

Each gap is committed separately so reviewers can step through commit by commit.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./internal/provider/ -count=1 -timeout=120s`
- [x] `make testacc TESTARGS='-run TestAccControlPlaneAgent_basic'` (acceptance test, requires CPLN_* env)
- [x] Manually verify `protocol_version` populates in state for an agent reporting `v2`.